### PR TITLE
Laravel 9 Compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install this package via Composer by adding the package and the repository link:
 "repositories": [
   {
     "type":"vcs",
-    "url": "https://github.com/peachysoftware/jetstream-team-invites"
+    "url": "https://github.com/truefrontier/jetstream-team-invites"
   }
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install this package via Composer by adding the package and the repository link:
 "repositories": [
   {
     "type":"vcs",
-    "url": "https://github.com/truefrontier/jetstream-team-invites"
+    "url": "https://github.com/peachysoftware/jetstream-team-invites"
   }
 ],
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0",
     "doctrine/dbal": "^2.9|^3.0",
-    "illuminate/support": "^8.0"
+    "illuminate/support": "^9.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0"


### PR DESCRIPTION
Changed the composer.json, the illuminate/support version to a min of 9.0, and PHP, removing the 7.4 dependency. So far so good. (Readme changes were an error and corrected). 