### PR TITLE
Added `php artisan migrate` setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Publish the config options:
 php artisan vendor:publish --provider="Truefrontier\JetstreamTeamInvites\JetstreamTeamInvitesServiceProvider" --force
 ```
 
+Run the DB migration:
+```bash
+php artisan migrate
+```
+
 Lastly, add the Invitation Trait to your Team and User Model:
 ```php
 use Truefrontier\JetstreamTeamInvites\Traits\HasJetstreamTeamInvites;
@@ -42,6 +47,10 @@ class User
 {
     use HasJetstreamTeamInvites;
 ```
+
+____
+
+Enabling this package disables automatic team creation for new users by default. To enable it, look in the `config/truefrontier_team_invites.php` config file.
 
 ## License
 


### PR DESCRIPTION
Made the README file elaborate a bit more - running DB migration is required for this to work, and the fact that new teams aren't created by default for new users also went over my head when initially installing.

I think these edits could help.